### PR TITLE
Add configuration toggles for aliases and completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ zstyle ':omz:plugins:pnpm' global-path no
 
 ## Aliases
 
+By default, this plugin loads a wide range of aliases. If you prefer to disable them, add the following line to your `.zshrc`:
+
+```zsh
+zstyle ':omz:plugins:pnpm' aliases no
+```
+
 | Alias | Command                              | Description                                                                             |
 | ----- | ------------------------------------ | --------------------------------------------------------------------------------------- |
 | p     | `pnpm`                               | The pnpm command                                                                        |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ zstyle ':omz:plugins:pnpm' aliases no
 | pab   | `pnpm approve-builds`                | Approve dependencies for running scripts during installation                            |
 | pf    | `pnpm -r --filter`                   | Use filter in monorepo root directory                                                   |
 
+## Completion
+
+This plugin automatically initializes and sources native `pnpm` shell completions for Zsh. 
+
+To disable this feature and handle completions manually, add the following line to your `.zshrc`:
+
+```zsh
+zstyle ':omz:plugins:pnpm' completion no
+```
+
 ## CHANGELOG
 
 ### 2025-02-15

--- a/pnpm.plugin.zsh
+++ b/pnpm.plugin.zsh
@@ -13,48 +13,49 @@ if zstyle -T ':omz:plugins:pnpm' global-path; then
   unset bindir
 fi
 
-# Aliases
+if zstyle -T ':omz:plugins:pnpm' aliases; then
+  # Aliases
+  alias p='pnpm'
 
-alias p='pnpm'
+  # Dependencies
+  alias pa='pnpm add'
+  alias pad='pnpm add --save-dev'
+  alias pap='pnpm add --save-peer'
+  alias prm='pnpm remove'
+  alias pin='pnpm install'
+  alias pinf='pnpm install --frozen-lockfile'
+  alias pls='pnpm list'
+  alias pu='pnpm update'
+  alias pui='pnpm update --interactive'
+  alias puil='pnpm update --interactive --latest'
 
-# Dependencies
-alias pa='pnpm add'
-alias pad='pnpm add --save-dev'
-alias pap='pnpm add --save-peer'
-alias prm='pnpm remove'
-alias pin='pnpm install'
-alias pinf='pnpm install --frozen-lockfile'
-alias pls='pnpm list'
-alias pu='pnpm update'
-alias pui='pnpm update --interactive'
-alias puil='pnpm update --interactive --latest'
+  # Global dependencies
+  alias pga='pnpm add --global'
+  alias pgls='pnpm list --global'
+  alias pgrm='pnpm remove --global'
+  alias pgu='pnpm update --global'
 
-# Global dependencies
-alias pga='pnpm add --global'
-alias pgls='pnpm list --global'
-alias pgrm='pnpm remove --global'
-alias pgu='pnpm update --global'
+  # Run scripts
+  alias pr='pnpm run'
+  alias prun='pnpm run'
+  alias pd='pnpm run dev'
+  alias pb='pnpm run build'
+  alias psv='pnpm run serve'
+  alias pst='pnpm start'
+  alias pt='pnpm test'
+  alias ptc='pnpm test --coverage'
+  alias pln='pnpm run lint'
+  alias pdocs='pnpm run docs'
+  alias pfmt='pnpm run format'
+  alias pex='pnpm exec'
+  alias pdx='pnpm dlx'
 
-# Run scripts
-alias pr='pnpm run'
-alias prun='pnpm run'
-alias pd='pnpm run dev'
-alias pb='pnpm run build'
-alias psv='pnpm run serve'
-alias pst='pnpm start'
-alias pt='pnpm test'
-alias ptc='pnpm test --coverage'
-alias pln='pnpm run lint'
-alias pdocs='pnpm run docs'
-alias pfmt='pnpm run format'
-alias pex='pnpm exec'
-alias pdx='pnpm dlx'
+  # Misc
+  alias pi='pnpm init'
+  alias ppub='pnpm publish'
+  alias pc='pnpm create'
+  alias pab='pnpm approve-builds'
 
-# Misc
-alias pi='pnpm init'
-alias ppub='pnpm publish'
-alias pc='pnpm create'
-alias pab='pnpm approve-builds'
-
-# Monorepo
-alias pf='pnpm -r --filter'
+  # Monorepo
+  alias pf='pnpm -r --filter'
+fi

--- a/pnpm.plugin.zsh
+++ b/pnpm.plugin.zsh
@@ -59,3 +59,7 @@ if zstyle -T ':omz:plugins:pnpm' aliases; then
   # Monorepo
   alias pf='pnpm -r --filter'
 fi
+
+if zstyle -T ':omz:plugins:pnpm' completion; then
+  source <(pnpm completion zsh)
+fi


### PR DESCRIPTION
This PR introduces configuration toggles for the plugin, allowing users to disable `aliases` if desired. It also enables `completion` by default, while providing an option to turn it off.